### PR TITLE
Add MXN Currency to supported currencies

### DIFF
--- a/src/rates/currencies.ts
+++ b/src/rates/currencies.ts
@@ -59,3 +59,24 @@ export class GHS extends Currency {
  * @remarks
  * When adding more fiat currencies, use the ISO 4217 currency code in uppercase as the symbol.
  */
+
+/**
+ * Represents the Mexican Peso (MXN) currency.
+ *
+ * Sources: Binance (P2P)
+ *
+ * Other reliable P2P MXN sources:
+ * - Paxful: https://paxful.com
+ * - AirTM: https://www.airtm.com
+ * - Binance P2P: https://p2p.binance.com (already integrated)
+ * - Bitso: https://bitso.com
+ */
+export class MXN extends Currency {
+  constructor() {
+    super('MXN', [
+      { source: new Binance(), pattern: CronExpression.EVERY_5_MINUTES },
+      { source: new Quidax(), pattern: CronExpression.EVERY_5_MINUTES },
+    ]);
+  }
+}
+

--- a/src/rates/dto/get-rates.dto.ts
+++ b/src/rates/dto/get-rates.dto.ts
@@ -4,8 +4,8 @@ import { IsArray, IsIn, IsNotEmpty } from 'class-validator';
 export type Stablecoin = 'USDT' | 'USDC';
 const coin = ['USDT', 'USDC'];
 
-export type Fiat = 'KES' | 'NGN' | 'GHS' | 'TZS' | 'UGX' | 'XOF';
-const fiat = ['KES', 'NGN', 'GHS', 'TZS', 'UGX', 'XOF'];
+export type Fiat = 'KES' | 'NGN' | 'GHS' | 'TZS' | 'UGX' | 'XOF' | 'MXN';
+const fiat = ['KES', 'NGN', 'GHS', 'TZS', 'UGX', 'XOF', 'MXN'];
 
 export class GetRatesDTO {
   @ApiProperty({


### PR DESCRIPTION
### Description

Summary
Added support for fetching USDT and USDC rates for the Mexican Peso (MXN) via Binance.
Updated DTOs and currency configuration to recognize MXN as a supported fiat.
Documented other reliable P2P MXN sources for future integration.


<img width="1131" alt="image" src="https://github.com/user-attachments/assets/aedc487a-2244-4e8b-bf7c-8c8c55140e55" />
USDT/MXN rates being fetched from binance and quidax, as seen in the locally running postgres db


And, to fetch the rates when running the app locally (npm dev server) :-  

```bash
curl -X 'GET' \
  'http://localhost:8000/rates/USDT/MXN' \
  -H 'accept: */*'
[{"stablecoin":"USDT","fiat":"MXN","sources":["binance"],"buyRate":19.79,"sellRate":19.63,"timestamp":"2025-04-30T13:54:16.053Z"}]%                                                         
```  

### References

Closes #9  


### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
