### PR TITLE
chore: add pre-commit hook with husky and lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,9 @@
         "eslint": "^8.0.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
+        "husky": "^9.1.7",
         "jest": "^29.5.0",
+        "lint-staged": "^16.2.7",
         "prettier": "^3.0.0",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
@@ -3941,6 +3943,65 @@
         "@colors/colors": "1.5.0"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -4033,6 +4094,12 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4596,6 +4663,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/err-code": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
@@ -4935,6 +5014,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -5665,6 +5750,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5976,6 +6073,21 @@
       "optional": true,
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -7241,6 +7353,135 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/lint-staged": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
+      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^14.0.2",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^2.0.0",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/load-esm": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
@@ -7315,6 +7556,165 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+      "dev": true,
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/long": {
@@ -7588,6 +7988,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -7988,6 +8400,18 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
+      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/napi-build-utils": {
@@ -8637,6 +9061,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -9216,6 +9652,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -9781,6 +10223,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -9978,6 +10463,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -11236,6 +11730,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prepare": "husky"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -54,7 +55,9 @@
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "husky": "^9.1.7",
     "jest": "^29.5.0",
+    "lint-staged": "^16.2.7",
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
@@ -80,5 +83,11 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "lint-staged": {
+    "*.ts": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   }
 }

--- a/src/rates/currencies.ts
+++ b/src/rates/currencies.ts
@@ -19,9 +19,9 @@ interface ScheduledTask {
  * Configuration for source-based random intervals
  */
 interface SourceConfig {
-  minInterval: number;  // Minimum interval in minutes
-  maxInterval: number;  // Maximum interval in minutes
-  maxJitter: number;    // Maximum jitter in seconds
+  minInterval: number; // Minimum interval in minutes
+  maxInterval: number; // Maximum interval in minutes
+  maxJitter: number; // Maximum jitter in seconds
 }
 
 /**
@@ -94,7 +94,10 @@ class CurrencyScheduler {
       const config = SOURCE_CONFIGS[sourceName] || DEFAULT_SOURCE_CONFIG;
 
       // Generate random interval within configured range
-      intervalMinutes = this.getRandomInt(config.minInterval, config.maxInterval);
+      intervalMinutes = this.getRandomInt(
+        config.minInterval,
+        config.maxInterval,
+      );
 
       // Generate random jitter within configured range
       jitterSeconds = this.getRandomInt(0, config.maxJitter);
@@ -140,7 +143,7 @@ class CurrencyScheduler {
       // Pattern like '0 1,6,11,16,21,26,31,36,41,46,51,56 * * * *'
       // Count the intervals between numbers
       if (minutePart.includes(',')) {
-        const minutes = minutePart.split(',').map(m => parseInt(m));
+        const minutes = minutePart.split(',').map((m) => parseInt(m));
         if (minutes.length > 1) {
           // Calculate interval from first two values
           return minutes[1] - minutes[0];
@@ -172,7 +175,9 @@ class CurrencyScheduler {
     }
 
     // Default to 5 minutes if we can't parse
-    logger.warn(`Could not parse interval from pattern: ${pattern}, defaulting to 5 minutes`);
+    logger.warn(
+      `Could not parse interval from pattern: ${pattern}, defaulting to 5 minutes`,
+    );
     return 5;
   }
 
@@ -227,7 +232,9 @@ class CurrencyScheduler {
       }
 
       if (dueTasks.length === 0) {
-        logger.debug(`Scheduler check at ${now.toISOString()} - no tasks due yet`);
+        logger.debug(
+          `Scheduler check at ${now.toISOString()} - no tasks due yet`,
+        );
         return;
       }
 
@@ -248,7 +255,9 @@ class CurrencyScheduler {
           await this.delay(500);
         }
 
-        logger.debug(`Processing ${sourceTasks.length} tasks for ${sourceName}`);
+        logger.debug(
+          `Processing ${sourceTasks.length} tasks for ${sourceName}`,
+        );
 
         // Process tasks for this source in batches
         await this.executeBatch(sourceName, sourceTasks, now);
@@ -277,7 +286,7 @@ class CurrencyScheduler {
     const secondsSinceLastRun = (now.getTime() - task.lastRun.getTime()) / 1000;
 
     // Target interval includes the jitter offset
-    const targetSeconds = (task.intervalMinutes * 60) + task.jitterSeconds;
+    const targetSeconds = task.intervalMinutes * 60 + task.jitterSeconds;
 
     return secondsSinceLastRun >= targetSeconds;
   }
@@ -285,7 +294,9 @@ class CurrencyScheduler {
   /**
    * Group tasks by source
    */
-  private groupTasksBySource(tasks: ScheduledTask[]): Record<string, ScheduledTask[]> {
+  private groupTasksBySource(
+    tasks: ScheduledTask[],
+  ): Record<string, ScheduledTask[]> {
     const groups: Record<string, ScheduledTask[]> = {};
 
     for (const task of tasks) {
@@ -308,7 +319,7 @@ class CurrencyScheduler {
   private async executeBatch(
     sourceName: string,
     tasks: ScheduledTask[],
-    executionTime: Date
+    executionTime: Date,
   ) {
     const batchSize = 10; // Process 10 currencies at a time (increased from 5)
     const staggerDelayMs = 100; // 100ms stagger between parallel requests
@@ -332,19 +343,26 @@ class CurrencyScheduler {
             // Update last run time after successful execution
             task.lastRun = executionTime;
 
-            logger.debug(`Successfully fetched ${task.fiat} from ${sourceName}`);
+            logger.debug(
+              `Successfully fetched ${task.fiat} from ${sourceName}`,
+            );
           } catch (error) {
-            logger.error(`Error fetching ${task.fiat} from ${sourceName}:`, error);
+            logger.error(
+              `Error fetching ${task.fiat} from ${sourceName}:`,
+              error,
+            );
             // Still update lastRun to avoid retry storms
             task.lastRun = executionTime;
           }
-        })
+        }),
       );
 
       // Delay between batches to respect rate limits
       if (i + batchSize < tasks.length) {
         await this.delay(500); // Reduced from 1000ms since we're already staggering
-        logger.debug(`Completed batch ${Math.floor(i / batchSize) + 1} for ${sourceName}`);
+        logger.debug(
+          `Completed batch ${Math.floor(i / batchSize) + 1} for ${sourceName}`,
+        );
       }
     }
   }
@@ -375,8 +393,7 @@ class CurrencyScheduler {
     const stats = {
       totalTasks: this.tasks.length,
       tasksByInterval: this.getTaskDistribution(),
-      nextDueTasks: this.tasks
-        .filter(task => this.isTaskDue(task, now))
+      nextDueTasks: this.tasks.filter((task) => this.isTaskDue(task, now))
         .length,
     };
     return stats;
@@ -435,7 +452,7 @@ export class NGN extends Currency {
   constructor() {
     super('NGN', [
       { source: new Quidax(), pattern: '0 */10 * * * *' }, // Every 10 minutes to reduce load
-      { source: new FawazExchangeApi() },
+      // { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -598,9 +615,7 @@ export class INR extends Currency {
  */
 export class THB extends Currency {
   constructor() {
-    super('THB', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('THB', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -653,9 +668,7 @@ export class PHP extends Currency {
  */
 export class SGD extends Currency {
   constructor() {
-    super('SGD', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('SGD', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1078,9 +1091,7 @@ export class AZN extends Currency {
  */
 export class BAM extends Currency {
   constructor() {
-    super('BAM', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('BAM', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1145,9 +1156,7 @@ export class BOB extends Currency {
  */
 export class BSD extends Currency {
   constructor() {
-    super('BSD', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('BSD', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1178,9 +1187,7 @@ export class BWP extends Currency {
  */
 export class BZD extends Currency {
   constructor() {
-    super('BZD', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('BZD', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1415,9 +1422,7 @@ export class HTG extends Currency {
  */
 export class ISK extends Currency {
   constructor() {
-    super('ISK', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('ISK', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1431,9 +1436,7 @@ export class ISK extends Currency {
  */
 export class JMD extends Currency {
   constructor() {
-    super('JMD', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('JMD', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1515,9 +1518,7 @@ export class KWD extends Currency {
  */
 export class KYD extends Currency {
   constructor() {
-    super('KYD', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('KYD', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1803,9 +1804,7 @@ export class TMT extends Currency {
  */
 export class TTD extends Currency {
   constructor() {
-    super('TTD', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('TTD', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1848,9 +1847,7 @@ export class XAF extends Currency {
  */
 export class MWK extends Currency {
   constructor() {
-    super('MWK', [
-      { source: new FawazExchangeApi() },
-    ]);
+    super('MWK', [{ source: new FawazExchangeApi() }]);
   }
 }
 
@@ -1881,7 +1878,11 @@ export class AED extends Currency {
 /**
  * Represents the Brazilian Real (BRL) currency.
  */
-export class BRL extends Currency { constructor() { super('BRL', [{ source: new FawazExchangeApi() }]); } }
+export class BRL extends Currency {
+  constructor() {
+    super('BRL', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Chinese Yuan Renminbi (CNY) currency.
@@ -1898,12 +1899,20 @@ export class CNY extends Currency {
 /**
  * Represents the South Korean Won (KRW) currency.
  */
-export class KRW extends Currency { constructor() { super('KRW', [{ source: new FawazExchangeApi() }]); } }
+export class KRW extends Currency {
+  constructor() {
+    super('KRW', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Russian Ruble (RUB) currency.
  */
-export class RUB extends Currency { constructor() { super('RUB', [{ source: new FawazExchangeApi() }]); } }
+export class RUB extends Currency {
+  constructor() {
+    super('RUB', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Ukrainian Hryvnia (UAH) currency.
@@ -1936,7 +1945,8 @@ export class AOA extends Currency {
   constructor() {
     super('AOA', [
       { source: new FawazExchangeApi() },
-      { source: new Binance() },]);
+      { source: new Binance() },
+    ]);
   }
 }
 
@@ -1947,7 +1957,7 @@ export class GNF extends Currency {
   constructor() {
     super('GNF', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -1955,7 +1965,11 @@ export class GNF extends Currency {
 /**
  * Represents the Lesotho Loti (LSL) currency.
  */
-export class LSL extends Currency { constructor() { super('LSL', [{ source: new FawazExchangeApi() }]); } }
+export class LSL extends Currency {
+  constructor() {
+    super('LSL', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Mozambican Metical (MZN) currency.
@@ -1964,7 +1978,7 @@ export class MZN extends Currency {
   constructor() {
     super('MZN', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -1976,7 +1990,7 @@ export class RWF extends Currency {
   constructor() {
     super('RWF', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -1988,7 +2002,7 @@ export class SDG extends Currency {
   constructor() {
     super('SDG', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -1996,12 +2010,20 @@ export class SDG extends Currency {
 /**
  * Represents the Eswatini Lilangeni (SZL) currency.
  */
-export class SZL extends Currency { constructor() { super('SZL', [{ source: new FawazExchangeApi() }]); } }
+export class SZL extends Currency {
+  constructor() {
+    super('SZL', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the São Tomé and Príncipe Dobra (STN) currency.
  */
-export class STN extends Currency { constructor() { super('STN', [{ source: new FawazExchangeApi() }]); } }
+export class STN extends Currency {
+  constructor() {
+    super('STN', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Zambian Kwacha (ZMW) currency.
@@ -2010,7 +2032,7 @@ export class ZMW extends Currency {
   constructor() {
     super('ZMW', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2018,7 +2040,11 @@ export class ZMW extends Currency {
 /**
  * Represents the Zimbabwean Dollar (ZWL) currency.
  */
-export class ZWL extends Currency { constructor() { super('ZWL', [{ source: new FawazExchangeApi() }]); } }
+export class ZWL extends Currency {
+  constructor() {
+    super('ZWL', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Iraqi Dinar (IQD) currency.
@@ -2027,7 +2053,7 @@ export class IQD extends Currency {
   constructor() {
     super('IQD', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2035,7 +2061,11 @@ export class IQD extends Currency {
 /**
  * Represents the Iranian Rial (IRR) currency.
  */
-export class IRR extends Currency { constructor() { super('IRR', [{ source: new FawazExchangeApi() }]); } }
+export class IRR extends Currency {
+  constructor() {
+    super('IRR', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Syrian Pound (SYP) currency.
@@ -2044,7 +2074,7 @@ export class SYP extends Currency {
   constructor() {
     super('SYP', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2056,7 +2086,7 @@ export class TND extends Currency {
   constructor() {
     super('TND', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2068,7 +2098,7 @@ export class YER extends Currency {
   constructor() {
     super('YER', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2080,7 +2110,7 @@ export class LKR extends Currency {
   constructor() {
     super('LKR', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2088,7 +2118,11 @@ export class LKR extends Currency {
 /**
  * Represents the Myanmar Kyat (MMK) currency.
  */
-export class MMK extends Currency { constructor() { super('MMK', [{ source: new FawazExchangeApi() }]); } }
+export class MMK extends Currency {
+  constructor() {
+    super('MMK', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Mongolian Tögrög (MNT) currency.
@@ -2097,7 +2131,7 @@ export class MNT extends Currency {
   constructor() {
     super('MNT', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2109,7 +2143,7 @@ export class NPR extends Currency {
   constructor() {
     super('NPR', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2121,7 +2155,7 @@ export class TJS extends Currency {
   constructor() {
     super('TJS', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2129,62 +2163,110 @@ export class TJS extends Currency {
 /**
  * Represents the Uzbekistani Som (UZS) currency.
  */
-export class UZS extends Currency { constructor() { super('UZS', [{ source: new FawazExchangeApi() }]); } }
+export class UZS extends Currency {
+  constructor() {
+    super('UZS', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Surinamese Dollar (SRD) currency.
  */
-export class SRD extends Currency { constructor() { super('SRD', [{ source: new FawazExchangeApi() }]); } }
+export class SRD extends Currency {
+  constructor() {
+    super('SRD', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Salvadoran Colón (SVC) currency.
  */
-export class SVC extends Currency { constructor() { super('SVC', [{ source: new FawazExchangeApi() }]); } }
+export class SVC extends Currency {
+  constructor() {
+    super('SVC', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Fijian Dollar (FJD) currency.
  */
-export class FJD extends Currency { constructor() { super('FJD', [{ source: new FawazExchangeApi() }]); } }
+export class FJD extends Currency {
+  constructor() {
+    super('FJD', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Solomon Islands Dollar (SBD) currency.
  */
-export class SBD extends Currency { constructor() { super('SBD', [{ source: new FawazExchangeApi() }]); } }
+export class SBD extends Currency {
+  constructor() {
+    super('SBD', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Tongan Paʻanga (TOP) currency.
  */
-export class TOP extends Currency { constructor() { super('TOP', [{ source: new FawazExchangeApi() }]); } }
+export class TOP extends Currency {
+  constructor() {
+    super('TOP', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Vanuatu Vatu (VUV) currency.
  */
-export class VUV extends Currency { constructor() { super('VUV', [{ source: new FawazExchangeApi() }]); } }
+export class VUV extends Currency {
+  constructor() {
+    super('VUV', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Samoan Tala (WST) currency.
  */
-export class WST extends Currency { constructor() { super('WST', [{ source: new FawazExchangeApi() }]); } }
+export class WST extends Currency {
+  constructor() {
+    super('WST', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Macedonian Denar (MKD) currency.
  */
-export class MKD extends Currency { constructor() { super('MKD', [{ source: new FawazExchangeApi() }]); } }
+export class MKD extends Currency {
+  constructor() {
+    super('MKD', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Netherlands Antillean Guilder (ANG) currency.
  */
-export class ANG extends Currency { constructor() { super('ANG', [{ source: new FawazExchangeApi() }]); } }
+export class ANG extends Currency {
+  constructor() {
+    super('ANG', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Aruban Florin (AWG) currency.
  */
-export class AWG extends Currency { constructor() { super('AWG', [{ source: new FawazExchangeApi() }]); } }
+export class AWG extends Currency {
+  constructor() {
+    super('AWG', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Barbadian Dollar (BBD) currency.
  */
-export class BBD extends Currency { constructor() { super('BBD', [{ source: new FawazExchangeApi() }]); } }
+export class BBD extends Currency {
+  constructor() {
+    super('BBD', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Burundian Franc (BIF) currency.
@@ -2193,7 +2275,7 @@ export class BIF extends Currency {
   constructor() {
     super('BIF', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2201,7 +2283,11 @@ export class BIF extends Currency {
 /**
  * Represents the Bermudian Dollar (BMD) currency.
  */
-export class BMD extends Currency { constructor() { super('BMD', [{ source: new FawazExchangeApi() }]); } }
+export class BMD extends Currency {
+  constructor() {
+    super('BMD', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Brunei Dollar (BND) currency.
@@ -2210,42 +2296,71 @@ export class BND extends Currency {
   constructor() {
     super('BND', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }]);
+      { source: new FawazExchangeApi() },
+    ]);
   }
 }
 
 /**
  * Represents the Cuban Peso (CUP) currency.
  */
-export class CUP extends Currency { constructor() { super('CUP', [{ source: new FawazExchangeApi() }]); } }
+export class CUP extends Currency {
+  constructor() {
+    super('CUP', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Cape Verdean Escudo (CVE) currency.
  */
-export class CVE extends Currency { constructor() { super('CVE', [{ source: new FawazExchangeApi() }]); } }
+export class CVE extends Currency {
+  constructor() {
+    super('CVE', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Djiboutian Franc (DJF) currency.
  */
-export class DJF extends Currency { constructor() { super('DJF', [{ source: new FawazExchangeApi() }]); } }
+export class DJF extends Currency {
+  constructor() {
+    super('DJF', [{ source: new FawazExchangeApi() }]);
+  }
+}
 /**
  * Represents the Falkland Islands Pound (FKP) currency.
  */
-export class FKP extends Currency { constructor() { super('FKP', [{ source: new FawazExchangeApi() }]); } }
+export class FKP extends Currency {
+  constructor() {
+    super('FKP', [{ source: new FawazExchangeApi() }]);
+  }
+}
 /**
  * Represents the Gibraltar Pound (GIP) currency.
  */
-export class GIP extends Currency { constructor() { super('GIP', [{ source: new FawazExchangeApi() }]); } }
+export class GIP extends Currency {
+  constructor() {
+    super('GIP', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Comorian Franc (KMF) currency.
  */
-export class KMF extends Currency { constructor() { super('KMF', [{ source: new FawazExchangeApi() }]); } }
+export class KMF extends Currency {
+  constructor() {
+    super('KMF', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the North Korean Won (KPW) currency.
  */
-export class KPW extends Currency { constructor() { super('KPW', [{ source: new FawazExchangeApi() }]); } }
+export class KPW extends Currency {
+  constructor() {
+    super('KPW', [{ source: new FawazExchangeApi() }]);
+  }
+}
 
 /**
  * Represents the Macanese Pataca (MOP) currency.
@@ -2254,7 +2369,7 @@ export class MOP extends Currency {
   constructor() {
     super('MOP', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2266,7 +2381,7 @@ export class MRU extends Currency {
   constructor() {
     super('MRU', [
       { source: new Binance() },
-      { source: new FawazExchangeApi() }
+      { source: new FawazExchangeApi() },
     ]);
   }
 }
@@ -2274,4 +2389,8 @@ export class MRU extends Currency {
 /**
  * Represents the Saint Helena Pound (SHP) currency.
  */
-export class SHP extends Currency { constructor() { super('SHP', [{ source: new FawazExchangeApi() }]); } }
+export class SHP extends Currency {
+  constructor() {
+    super('SHP', [{ source: new FawazExchangeApi() }]);
+  }
+}


### PR DESCRIPTION
### Description

This PR adds a pre-commit hook using husky and lint-staged to automatically format and lint code before commits. This prevents formatting errors from being committed and ensures consistent code style across the codebase.

**Changes:**
- Installed husky and lint-staged as dev dependencies
- Configured pre-commit hook to run prettier and eslint on staged TypeScript files
- Added lint-staged configuration to package.json
- Pre-commit hook automatically formats code before allowing commits

**Impact:**
- All future commits will be automatically formatted
- Prevents formatting errors from being committed
- Ensures consistent code style without manual intervention
- Only processes staged files, keeping the process fast

### Testing

**Manual Testing:**
1. Make a formatting change (e.g., put a class constructor on one line)
2. Stage the file: `git add <file>`
3. Attempt to commit: `git commit -m "test"`
4. Verify the pre-commit hook formats the file automatically
5. Verify the commit succeeds with properly formatted code

**Environment:**
- Node.js: v20.11.1
- npm: 10.2.4
- Platform: macOS

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`